### PR TITLE
RabbitMQ related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Full documentation can be found here: [Netskope Cloud Exchange](https://docs.net
 	b. create self signed certificate - or use personal certificates<br>
 	`openssl req -x509 -newkey rsa:4096 -keyout data/ssl_certs/cte_cert_key.key -out data/ssl_certs/cte_cert.crt -sha256 -days 365 -nodes -subj '/CN=localhost'`
  4. Launch Cloud Exchange 3<br>
- 	a. `sudo docker-compose up -d`<br>
+ 	a. `sudo docker-compose --compatibility up -d`<br>
  5. Open Browser to `http(s)://<host ip address>`<br>
 	 
 

--- a/data/rabbitmq/custom.conf
+++ b/data/rabbitmq/custom.conf
@@ -1,1 +1,2 @@
 consumer_timeout = 86400000
+disk_free_limit.absolute = 2GB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,10 +51,6 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=token
       - ANALYTICS_BASE_URL=https://reporting.netskope.tech
       - ANALYTICS_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpbnN0YWxsYXRpb25faWQiOiJjMDAyIn0.w8SVrTcDjk8PkR4IcbWGwOyf6-OWfCUyOoCTgZvqHqc
-      #- MOCK_URL=http://10.0.9.93:8888
-      #- MAX_MAINTENANCE_WINDOW_MINUTES=15
-      #- PULL_THREADS=6
-      #- MAX_WAIT_ON_LOCK_IN_MINUTES=240
     restart: on-failure:5
     logging:
       options:
@@ -86,7 +82,7 @@ services:
     image: index.docker.io/containrrr/watchtower:1.3.0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /root/.docker/config.json:/config.json # uncomment this line if repo requires authentication
+      # - /root/.docker/config.json:/config.json # uncomment this line if repo requires authentication
     environment:
       - WATCHTOWER_HTTP_API=true
       - WATCHTOWER_HTTP_API_TOKEN=token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=token
       - ANALYTICS_BASE_URL=https://reporting.netskope.tech
       - ANALYTICS_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpbnN0YWxsYXRpb25faWQiOiJjMDAyIn0.w8SVrTcDjk8PkR4IcbWGwOyf6-OWfCUyOoCTgZvqHqc
-      - MOCK_URL=http://10.0.9.93:8888
+      #- MOCK_URL=http://10.0.9.93:8888
       #- MAX_MAINTENANCE_WINDOW_MINUTES=15
       #- PULL_THREADS=6
       #- MAX_WAIT_ON_LOCK_IN_MINUTES=240

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
     ports:
       - '15672:15672'
       - '5672:5672'
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
   mongodb-primary:
     image: index.docker.io/bitnami/mongodb:4.4
     volumes:
@@ -27,6 +31,10 @@ services:
     restart: on-failure:5
     ports:
       - '27017:27017'
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
   core:
     image: index.docker.io/netskopetechnicalalliances/cloudexchange:core3-latest
     volumes:
@@ -70,6 +78,10 @@ services:
       - core
     labels:
       - com.centurylinklabs.watchtower.enable=true
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
   watchtower:
     image: index.docker.io/containrrr/watchtower:1.3.0
     volumes:
@@ -83,3 +95,7 @@ services:
     ports:
       - 8080:8080
     command: --http-api-update
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 version: "3.3"
 services:
   rabbitmq-stats:
-    image: docker.io/bitnami/rabbitmq:3.8
+    image: index.docker.io/bitnami/rabbitmq:3.8
     environment:
       - RABBITMQ_NODE_TYPE=stats
       - RABBITMQ_NODE_NAME=rabbit@rabbitmq-stats
       - RABBITMQ_ERL_COOKIE=s3cr3tc00ki3
       - RABBITMQ_SECURE_PASSWORD=yes
+      - RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT=1
     restart: on-failure:5
     volumes:
       - ./data/rabbitmq/custom.conf:/bitnami/rabbitmq/conf/custom.conf:z
@@ -14,7 +15,7 @@ services:
       - '15672:15672'
       - '5672:5672'
   mongodb-primary:
-    image: docker.io/bitnami/mongodb:4.4
+    image: index.docker.io/bitnami/mongodb:4.4
     volumes:
       - ./data/mongo-data:/bitnami/mongodb:z
     environment:
@@ -27,7 +28,7 @@ services:
     ports:
       - '27017:27017'
   core:
-    image: docker.io/netskopetechnicalalliances/cloudexchange:core3-latest
+    image: index.docker.io/netskopetechnicalalliances/cloudexchange:core3-latest
     volumes:
       - ./data/custom_plugins:/opt/netskope/plugins/custom_plugins:z
       - /var/run/docker.sock:/var/run/docker.sock
@@ -42,14 +43,22 @@ services:
       - WATCHTOWER_HTTP_API_TOKEN=token
       - ANALYTICS_BASE_URL=https://reporting.netskope.tech
       - ANALYTICS_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpbnN0YWxsYXRpb25faWQiOiJjMDAyIn0.w8SVrTcDjk8PkR4IcbWGwOyf6-OWfCUyOoCTgZvqHqc
+      - MOCK_URL=http://10.0.9.93:8888
+      #- MAX_MAINTENANCE_WINDOW_MINUTES=15
+      #- PULL_THREADS=6
+      #- MAX_WAIT_ON_LOCK_IN_MINUTES=240
     restart: on-failure:5
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
     depends_on:
       - mongodb-primary
       - rabbitmq-stats
     labels:
       - com.centurylinklabs.watchtower.enable=true
   ui:
-    image: docker.io/netskopetechnicalalliances/cloudexchange:ui3-latest
+    image: index.docker.io/netskopetechnicalalliances/cloudexchange:ui3-latest
     restart: on-failure:5
     environment:
       - CE_API_URL=http://core
@@ -62,10 +71,10 @@ services:
     labels:
       - com.centurylinklabs.watchtower.enable=true
   watchtower:
-    image: containrrr/watchtower:1.0.3
+    image: index.docker.io/containrrr/watchtower:1.3.0
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      # - /root/.docker/config.json:/config.json  # uncomment this line if repo requires authentication
+      - /root/.docker/config.json:/config.json # uncomment this line if repo requires authentication
     environment:
       - WATCHTOWER_HTTP_API=true
       - WATCHTOWER_HTTP_API_TOKEN=token
@@ -73,4 +82,4 @@ services:
     restart: on-failure:5
     ports:
       - 8080:8080
-    command: --interval 30 {"mode":"full","isActive":false}
+    command: --http-api-update


### PR DESCRIPTION
- Restricted memory allocated to RabbitMQ to 2GB
- Lowered RabbitMQ low disk space watermark to 2GB
- Updated image tags for watchtower
- Bumped watchtower version
- Added restrictions to logging file size (Maximum 5 files of 10MB each)